### PR TITLE
Fix step parameter in documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ $ circle-step-outputter --help
     --repoSlug [Default: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME]
     --buildNum [Default: $CIRCLE_BUILD_NUM]
     --token [Default: $CIRCLE_API_TOKEN]
-    --stepName [Default: "npm test"]
+    --step [Default: "npm test"]
 
   Examples
     $ circle-step-outputter --repoSlug="artemv/circleci-step-outputter" --buildNum=2


### PR DESCRIPTION
It's actually `step`, not `stepName`, see https://github.com/artemv/circleci-step-outputter/blob/0582754081f6ad700355209f7b5c73e32e18e20d/src/index.js#L67